### PR TITLE
Update hangons.js to handle audio attachments

### DIFF
--- a/hangons.js
+++ b/hangons.js
@@ -94,10 +94,17 @@ function parseData()
                 }
                 
                 else if (jsonData.conversation_state[i].conversation_state.event[j].chat_message.message_content.attachment !== undefined)
-                {//if it's an image
+                {
                     for (var k = 0; k < jsonData.conversation_state[i].conversation_state.event[j].chat_message.message_content.attachment.length; k++)
                     {
-                        message.content = jsonData.conversation_state[i].conversation_state.event[j].chat_message.message_content.attachment[k].embed_item["embeds.PlusPhoto.plus_photo"].url
+                        //image
+                        if (jsonData.conversation_state[i].conversation_state.event[j].chat_message.message_content.attachment.type == "PLUS_PHOTO")
+                                message.content = jsonData.conversation_state[i].conversation_state.event[j].chat_message.message_content.attachment[k].embed_item["embeds.PlusPhoto.plus_photo"].url
+                        //audio
+                        else if (jsonData.conversation_state[i].conversation_state.event[j].chat_message.message_content.attachment.type == "PLUS_AUDIO_V2")
+                                message.content = jsonData.conversation_state[i].conversation_state.event[j].chat_message.message_content.attachment[k].embed_item["embeds.PlusAudioV2.plus_audio_v2"].url
+
+
                     }
                 }
                 


### PR DESCRIPTION
I was analyzing a hangouts log that contained url/attachments for audio.  When the process came to line 100 an error was thrown because the process was attempting to get a URL for an image attachment.